### PR TITLE
Case 283614 - Updating the JWT encoding to use RS256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
+## 0.2.8
+* Updated JWT to use RS256 encoding instead of HS256.
+
+## 0.2.7
+* Updated dependencies.
+* Improved callbacks to avoid NULL Auth0 IDs.
+
 ## 0.2.6
-* Allow newer Auth0 library and jwt library
+* Allow newer Auth0 library and jwt library.
 
 ## 0.2.5
 * No Changes (version bump).

--- a/lib/sync_attr_with_auth0/auth0.rb
+++ b/lib/sync_attr_with_auth0/auth0.rb
@@ -17,7 +17,7 @@ module SyncAttrWithAuth0
         'jti' => UUIDTools::UUID.random_create.to_s
       }
 
-      jwt = JWT.encode(payload, JWT::Base64.url_decode(global_client_secret), 'HS256', { typ: 'JWT' })
+      jwt = JWT.encode(payload, JWT::Base64.url_decode(global_client_secret), 'RS256', { typ: 'JWT' })
 
       return jwt
     end # ::create_auth0_jwt

--- a/spec/sync_attr_with_auth0/auth0_spec.rb
+++ b/spec/sync_attr_with_auth0/auth0_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SyncAttrWithAuth0::Auth0 do
       expect(Time).to receive(:now).and_return(1)
       expect(UUIDTools::UUID).to receive(:random_create).and_return('uuid')
       expect(JWT::Base64).to receive(:url_decode).with('global client secret').and_return('decoded global client secret')
-      expect(JWT).to receive(:encode).with(mock_payload, 'decoded global client secret', 'HS256', { typ: 'JWT' }).and_return('jwt string')
+      expect(JWT).to receive(:encode).with(mock_payload, 'decoded global client secret', 'RS256', { typ: 'JWT' }).and_return('jwt string')
     end
 
     it "should create and return a java web token for auth0" do

--- a/sync_attr_with_auth0.gemspec
+++ b/sync_attr_with_auth0.gemspec
@@ -1,10 +1,10 @@
 Gem::Specification.new do |gem|
   gem.name          = 'sync_attr_with_auth0'
-  gem.version       = '0.2.7'
+  gem.version       = '0.2.8'
   gem.date          = '2016-07-26'
   gem.summary       = "Synchronize attributes on a local ActiveRecord user model with the user metadata store on Auth0"
   gem.description   = gem.summary
-  gem.authors       = ["Patrick McGraw", "Mike Oliver"]
+  gem.authors       = ["Patrick McGraw", "Mike Oliver", "Eric Anderson"]
   gem.email         = 'patrick@mcgraw-tech.com'
   gem.files         = [
     "lib/sync_attr_with_auth0.rb",


### PR DESCRIPTION
I updated the encoding for the JWTs to use RS256 instead of HS256.

I updated the changelog and incremented the version.